### PR TITLE
Fix #37 - Role Assignments not made when VNet not deployed

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Vend Subscriptions & Networking Scenarios (Deploy)
         id: vend
+        continue-on-error: true
         uses: azure/powershell@v1
         with:
           inlineScript: |

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -78,6 +78,28 @@ jobs:
             "SUBID=$outputValue" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           azPSVersion: "latest"
 
+      - name: Vend Subscriptions & Networking Scenarios (Deploy) - Retry
+        id: vend-retry
+        if: ${{ failure() }}
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            $inputObject = @{
+              DeploymentName        = 'pr-${{ env.GH_PR_NUMBER }}-lz-vend-{0}' -f (-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])
+              ManagementGroupId     = "bicep-lz-vending-automation"
+              Location              = "${{ env.ARM_LOCATION }}"
+              TemplateFile          = "./tests/lz-vending/full.test.bicep"
+              TemplateParameterObject =  @{
+                location = "${{ env.ARM_LOCATION }}"
+                prNumber = "${{ env.GH_PR_NUMBER }}"
+                subscriptionBillingScope = "${{ env.ARM_BILLING_SCOPE_RID }}"
+              }
+            }
+            $bicepDeployment = New-AzManagementGroupDeployment @inputObject
+            $outputValue = $bicepDeployment.Outputs.createdSubId.Value
+            "SUBID=$outputValue" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          azPSVersion: "latest"
+
       - name: Pester Tests
         id: pester
         uses: azure/powershell@v1

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -59,30 +59,6 @@ jobs:
 
       - name: Vend Subscriptions & Networking Scenarios (Deploy)
         id: vend
-        continue-on-error: true
-        uses: azure/powershell@v1
-        with:
-          inlineScript: |
-            $inputObject = @{
-              DeploymentName        = 'pr-${{ env.GH_PR_NUMBER }}-lz-vend-{0}' -f (-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])
-              ManagementGroupId     = "bicep-lz-vending-automation"
-              Location              = "${{ env.ARM_LOCATION }}"
-              TemplateFile          = "./tests/lz-vending/full.test.bicep"
-              TemplateParameterObject =  @{
-                location = "${{ env.ARM_LOCATION }}"
-                prNumber = "${{ env.GH_PR_NUMBER }}"
-                subscriptionBillingScope = "${{ env.ARM_BILLING_SCOPE_RID }}"
-              }
-            }
-            $bicepDeployment = New-AzManagementGroupDeployment @inputObject
-            $outputValue = $bicepDeployment.Outputs.createdSubId.Value
-            "SUBID=$outputValue" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          azPSVersion: "latest"
-
-      - name: Vend Subscriptions & Networking Scenarios (Deploy) - Retry
-        id: vend-retry
-        continue-on-error: true
-        if: ${{ failure() }}
         uses: azure/powershell@v1
         with:
           inlineScript: |

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Vend Subscriptions & Networking Scenarios (Deploy) - Retry
         id: vend-retry
+        continue-on-error: true
         if: ${{ failure() }}
         uses: azure/powershell@v1
         with:

--- a/src/self/subResourceWrapper/deploy.bicep
+++ b/src/self/subResourceWrapper/deploy.bicep
@@ -240,6 +240,9 @@ module createLzRoleAssignmentsSub '../../carml/v0.6.0/Microsoft.Authorization/ro
 }]
 
 module createLzRoleAssignmentsRsgs '../../carml/v0.6.0/Microsoft.Authorization/roleAssignments/deploy.bicep' = [for assignment in roleAssignmentsResourceGroups: if (roleAssignmentEnabled && !empty(roleAssignmentsResourceGroups)) {
+  dependsOn: [
+    createResourceGroupForLzNetworking
+  ]
   name: take('${deploymentNames.createLzRoleAssignmentsRsgs}-${uniqueString(assignment.principalId, assignment.definition, assignment.relativeScope)}', 64)
   params: {
     location: virtualNetworkLocation

--- a/src/self/subResourceWrapper/deploy.bicep
+++ b/src/self/subResourceWrapper/deploy.bicep
@@ -249,7 +249,7 @@ module createLzRoleAssignmentsRsgs '../../carml/v0.6.0/Microsoft.Authorization/r
     principalId: assignment.principalId
     roleDefinitionIdOrName: assignment.definition
     subscriptionId: subscriptionId
-    resourceGroupName: assignment.relativeScope
+    resourceGroupName: split(assignment.relativeScope, '/')[2]
     enableDefaultTelemetry: enableTelemetryForCarml
   }
 }]

--- a/tests/lz-vending/full.test.bicep
+++ b/tests/lz-vending/full.test.bicep
@@ -20,6 +20,7 @@ module createSub '../../main.bicep' = {
     subscriptionManagementGroupAssociationEnabled: true
     subscriptionManagementGroupId: 'bicep-lz-vending-automation-child'
     virtualNetworkEnabled: false
+    roleAssignmentEnabled: true
     roleAssignments: [
       {
         principalId: '7eca0dca-6701-46f1-b7b6-8b424dab50b3'
@@ -46,6 +47,7 @@ module hubSpoke '../../main.bicep' = {
     virtualNetworkPeeringEnabled: true
     virtualNetworkUseRemoteGateways: false
     hubNetworkResourceId: '/subscriptions/e4e7395f-dc45-411e-b425-95f75e470e16/resourceGroups/rsg-blzv-perm-hubs-001/providers/Microsoft.Network/virtualNetworks/vnet-uksouth-hub-blzv'
+    roleAssignmentEnabled: true
     roleAssignments: [
       {
         principalId: '7eca0dca-6701-46f1-b7b6-8b424dab50b3'

--- a/tests/lz-vending/full.test.bicep
+++ b/tests/lz-vending/full.test.bicep
@@ -46,6 +46,13 @@ module hubSpoke '../../main.bicep' = {
     virtualNetworkPeeringEnabled: true
     virtualNetworkUseRemoteGateways: false
     hubNetworkResourceId: '/subscriptions/e4e7395f-dc45-411e-b425-95f75e470e16/resourceGroups/rsg-blzv-perm-hubs-001/providers/Microsoft.Network/virtualNetworks/vnet-uksouth-hub-blzv'
+    roleAssignments: [
+      {
+        principalId: '7eca0dca-6701-46f1-b7b6-8b424dab50b3'
+        definition: 'Network Contributor'
+        relativeScope: '/resourceGroups/rsg-${location}-net-hs-pr-${prNumber}'
+      }
+    ]
   }
 }
 

--- a/tests/pester/full.tests.ps1
+++ b/tests/pester/full.tests.ps1
@@ -49,14 +49,22 @@ Describe "Bicep Landing Zone (Sub) Vending Tests" {
 
   Context "Role-Based Access Control Assignment Tests" {
     BeforeAll {
-      $allRoleAssignments = Get-AzRoleAssignment -Scope "/subscriptions/$subId" -ErrorAction SilentlyContinue
+      $allRoleAssignmentsSub = Get-AzRoleAssignment -Scope "/subscriptions/$subId" -ErrorAction SilentlyContinue
+      $allRoleAssignmentsRsg = Get-AzRoleAssignment -Scope "/subscriptions/$subId/resourceGroups/rsg-$location-net-hs-pr-$prNumber" -ErrorAction SilentlyContinue
     }
 
     It "Should Have a Role Assignment for an known AAD Group with the Reader role directly upon the Subscription" {
-      $roleAssignment = $allRoleAssignments | Where-Object { $_.ObjectId -eq "7eca0dca-6701-46f1-b7b6-8b424dab50b3" -and $_.RoleDefinitionName -eq "Reader" }
+      $roleAssignment = $allRoleAssignmentsSub | Where-Object { $_.ObjectId -eq "7eca0dca-6701-46f1-b7b6-8b424dab50b3" -and $_.RoleDefinitionName -eq "Reader" }
       $roleAssignment.ObjectId | Should -Be "7eca0dca-6701-46f1-b7b6-8b424dab50b3"
       $roleAssignment.RoleDefinitionName | Should -Be "Reader"
       $roleAssignment.scope | Should -Be "/subscriptions/$subId"
+    }
+
+    It "Should Have a Role Assignment for an known AAD Group with the Network Contributor role directly upon the Resource Group" {
+      $roleAssignment = $allRoleAssignmentsRsg | Where-Object { $_.ObjectId -eq "7eca0dca-6701-46f1-b7b6-8b424dab50b3" -and $_.RoleDefinitionName -eq "Network Contributor" }
+      $roleAssignment.ObjectId | Should -Be "7eca0dca-6701-46f1-b7b6-8b424dab50b3"
+      $roleAssignment.RoleDefinitionName | Should -Be "Network Contributor"
+      $roleAssignment.scope | Should -Be "/subscriptions/$subId/resourceGroups/rsg-$location-net-hs-pr-$prNumber"
     }
   }
 

--- a/tests/pester/full.tests.ps1
+++ b/tests/pester/full.tests.ps1
@@ -47,6 +47,19 @@ Describe "Bicep Landing Zone (Sub) Vending Tests" {
     }
   }
 
+  Context "Role-Based Access Control Assignment Tests" {
+    BeforeAll {
+      $allRoleAssignments = Get-AzRoleAssignment -Scope "/subscriptions/$subId" -ErrorAction SilentlyContinue
+    }
+
+    It "Should Have a Role Assignment for an known AAD Group with the Reader role directly upon the Subscription" {
+      $roleAssignment = $allRoleAssignments | Where-Object { $_.ObjectId -eq "7eca0dca-6701-46f1-b7b6-8b424dab50b3" -and $_.RoleDefinitionName -eq "Reader" }
+      $roleAssignment.ObjectId | Should -Be "7eca0dca-6701-46f1-b7b6-8b424dab50b3"
+      $roleAssignment.RoleDefinitionName | Should -Be "Reader"
+      $roleAssignment.scope | Should -Be "/subscriptions/$subId"
+    }
+  }
+
   Context "Hub Spoke - Resource Group Tests" {
     BeforeAll {
       $rsg = Get-AzResourceGroup -Name "rsg-$location-net-hs-pr-$prNumber" -ErrorAction SilentlyContinue


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR fixes #37 - Role Assignments not made when VNet not deployed by splitting the role assignment deployments into separate RSG & Sub deployments and using the `filter()` lambda function to split the `roleAssignments` parameter into 2 vars for this. 

Also added additional tests.

Then removed the incorrect depends on definition for the subscription level RBAC

## This PR fixes/adds/changes/removes

1. Fixes #37 
2. Adds RBAC checks to tests

### Breaking Changes

None

## Testing Evidence

Tests will be sufficient

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/bicep-lz-vending/wiki/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/bicep-lz-vending/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/bicep-lz-vending/issues)
- [ ] *(LZ-Vending Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/lz-vending/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/bicep-lz-vending/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/bicep-lz-vending/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/bicep-lz-vending/tree/main/.github/workflows/code-review.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
