### PR TITLE
Scope de-elevation

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -84,13 +84,20 @@ jobs:
         with:
           inlineScript: |
             Import-Module Pester -Force
-            $configuration = [PesterConfiguration]::Default
-            $configuration.TestResult.Enabled = $true
-            $configuration.Output.Verbosity = 'Detailed'
-            $container = New-PesterContainer -Path "./tests/pester/*.tests.ps1" -Data @{ subId = "${{ env.SUBID }}"; prNumber = "${{ env.GH_PR_NUMBER }}"; location = "${{ env.ARM_LOCATION }}" }
-            $configuration.Run.Container = $container
-            $configuration.Run.PassThru = $true
-            $result = Invoke-Pester -Configuration $configuration
+            $pesterConfiguration = @{
+              Run    = @{
+                Container = New-PesterContainer -Path "./tests/pester/full.tests.ps1" -Data @{
+                  subId    = "${{ env.SUBID }}"
+                  prNumber = "${{ env.GH_PR_NUMBER }}"
+                  location = "${{ env.ARM_LOCATION }}"
+                }
+                PassThru  = $true
+              }
+              Output = @{
+                Verbosity = 'Detailed'
+              }
+            }
+            $result = Invoke-Pester -Configuration $pesterConfiguration
             exit $result.FailedCount
           azPSVersion: "latest"
 

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,4 +1,4 @@
-name: Release Tests
+name: Pre-Release Tests
 
 on:
   pull_request:
@@ -7,8 +7,8 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  vending:
-    name: Vending Subscription for Tests and Networking Scenarios
+  release-tests:
+    name: Pre-Release Tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,41 @@
+name: Release Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  vending:
+    name: Vending Subscription for Tests and Networking Scenarios
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Pester Tests
+        id: pester
+        if: contains(github.ref, 'release')
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            Import-Module Pester -Force
+            $pesterConfiguration = @{
+              Run    = @{
+                Container = New-PesterContainer -Path "./tests/pester/release.tests.ps1"
+                PassThru  = $true
+              }
+              Output = @{
+                Verbosity = 'Detailed'
+              }
+            }
+            $result = Invoke-Pester -Configuration $pesterConfiguration
+            exit $result.FailedCount
+          azPSVersion: "latest"
+
+

--- a/main.bicep
+++ b/main.bicep
@@ -441,7 +441,7 @@ resource moduleTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (!dis
 }
 
 module createSubscription 'src/self/Microsoft.Subscription/aliases/deploy.bicep' = if (subscriptionAliasEnabled && empty(existingSubscriptionId)) {
-  scope: tenant()
+  scope: managementGroup()
   name: deploymentNames.createSubscription
   params: {
     subscriptionBillingScope: subscriptionBillingScope

--- a/src/self/Microsoft.Subscription/aliases/deploy.bicep
+++ b/src/self/Microsoft.Subscription/aliases/deploy.bicep
@@ -1,4 +1,4 @@
-targetScope = 'tenant'
+targetScope = 'managementGroup'
 
 @maxLength(63)
 @description('The name of the subscription alias. The string must be comprised of a-z, A-Z, 0-9, - and _. The maximum length is 63 characters.')
@@ -19,6 +19,7 @@ param subscriptionBillingScope string
 param subscriptionWorkload string = 'Production'
 
 resource subscriptionAlias 'Microsoft.Subscription/aliases@2021-10-01' = {
+  scope: tenant()
   name: subscriptionAliasName
   properties: {
     workload: subscriptionWorkload

--- a/tests/pester/release.tests.ps1
+++ b/tests/pester/release.tests.ps1
@@ -28,7 +28,6 @@ Describe "version.json file tests" {
 
     It "version.json file contains the required properties" {
       $versionFile.version | Should -Not -BeNullOrEmpty
-      $versionFile.gitTag | Should -Not -BeNullOrEmpty
       $versionFile.releaseNotes | Should -Not -BeNullOrEmpty
       $versionFile.releaseDateTimeUTC | Should -Not -BeNullOrEmpty
     }

--- a/tests/pester/release.tests.ps1
+++ b/tests/pester/release.tests.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory = $false)]
+  [string]
+  $versionFilePath = "./version.json"
+)
+
+Describe "version.json file tests" {
+
+  Context "version.json file tests" {
+
+    BeforeAll {
+      $versionFile = Get-Content $versionFilePath -Raw | ConvertFrom-Json
+      $gitRepoLatestTag = git describe --tags --abbrev=0
+      $releaseNotesUrlSplitLast = $versionFile.releaseNotes.Split("/")[-1]
+      $releaseNotesUrlStart = "https://github.com/Azure/bicep-lz-vending/releases/tag/v"
+
+      # Download the previous version.json file from the repo
+      $previousVersionRawUrl = "https://raw.githubusercontent.com/Azure/bicep-lz-vending/v1.2.2/version.json"
+      $previousVersionOutputFile = "./previousVersion.json"
+      Invoke-WebRequest -Uri $previousVersionRawUrl -OutFile $previousVersionOutputFile
+      $PreviousVersionFile = Get-Content $previousVersionOutputFile -Raw | ConvertFrom-Json
+    }
+
+    It "version.json file exists" {
+      $versionFile | Should -Not -BeNullOrEmpty
+    }
+
+    It "version.json file contains the required properties" {
+      $versionFile.version | Should -Not -BeNullOrEmpty
+      $versionFile.gitTag | Should -Not -BeNullOrEmpty
+      $versionFile.releaseNotes | Should -Not -BeNullOrEmpty
+      $versionFile.releaseDateTimeUTC | Should -Not -BeNullOrEmpty
+    }
+
+    It "version.json file version property has been updated and increased from the latest git tag" {
+      $versionFile.version | Should -BeGreaterThan $PreviousVersionFile.version
+    }
+
+    It "version.json file gitTag property has been updated and does not match the latest git tag" {
+      $versionFile.gitTag | Should -Not -Be $gitRepoLatestTag
+      $versionFile.gitTag | Should -BeGreaterThan $PreviousVersionFile.gitTag
+    }
+
+    It "version.json file releaseNotes property has been updated and URL last split on / does not match the latest git tag" {
+      $releaseNotesUrlSplitLast | Should -Not -Be $gitRepoLatestTag
+    }
+
+    It "version.json file releaseNotes property is a valid URL and has the correct format" {
+      $versionFile.releaseNotes | Should -BeLike "$releaseNotesUrlStart*"
+    }
+
+    It "version.json file releaseDateTimeUTC property has been updated and UTC time/date stamp if newer than the last value" {
+      $versionFile.releaseDateTimeUTC | Should -BeGreaterThan $PreviousVersionFile.releaseDateTimeUTC
+    }
+
+  }
+}

--- a/tests/pester/release.tests.ps1
+++ b/tests/pester/release.tests.ps1
@@ -16,7 +16,7 @@ Describe "version.json file tests" {
       $releaseNotesUrlStart = "https://github.com/Azure/bicep-lz-vending/releases/tag/v"
 
       # Download the previous version.json file from the repo
-      $previousVersionRawUrl = "https://raw.githubusercontent.com/Azure/bicep-lz-vending/v1.2.2/version.json"
+      $previousVersionRawUrl = "https://raw.githubusercontent.com/Azure/bicep-lz-vending/$gitRepoLatestTag/version.json"
       $previousVersionOutputFile = "./previousVersion.json"
       Invoke-WebRequest -Uri $previousVersionRawUrl -OutFile $previousVersionOutputFile
       $PreviousVersionFile = Get-Content $previousVersionOutputFile -Raw | ConvertFrom-Json
@@ -35,11 +35,6 @@ Describe "version.json file tests" {
 
     It "version.json file version property has been updated and increased from the latest git tag" {
       $versionFile.version | Should -BeGreaterThan $PreviousVersionFile.version
-    }
-
-    It "version.json file gitTag property has been updated and does not match the latest git tag" {
-      $versionFile.gitTag | Should -Not -Be $gitRepoLatestTag
-      $versionFile.gitTag | Should -BeGreaterThan $PreviousVersionFile.gitTag
     }
 
     It "version.json file releaseNotes property has been updated and URL last split on / does not match the latest git tag" {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,5 @@
 {
   "version": "1.2.2",
-  "gitTag": "v1.2.2",
   "releaseNotes": "https://github.com/Azure/bicep-lz-vending/releases/tag/v1.2.2",
   "releaseDateTimeUTC": "20230303T1611568711Z"
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

As per https://github.com/Azure/bicep-registry-modules/issues/394, this PR is de-elevating the scopes access is required to and no longer creating a tenant level deployment, which requires `/` RBAC access.

We also add some testing for releases

## This PR fixes/adds/changes/removes

1. Remove `/` scope access requirements and replace with `managementGroup()`
2. Add testing for releases

### Breaking Changes

Not technically breaking, but a cleanup of permissions could be done

## Testing Evidence

Tests will suffice

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/bicep-lz-vending/wiki/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/bicep-lz-vending/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/bicep-lz-vending/issues)
- [x] *(LZ-Vending Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/lz-vending/backlog)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/bicep-lz-vending/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/bicep-lz-vending/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/bicep-lz-vending/tree/main/.github/workflows/code-review.yml)
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
