### PR TITLE
AAD Renames

### DIFF
--- a/.github/scripts/Wipe-AlzTenant.ps1
+++ b/.github/scripts/Wipe-AlzTenant.ps1
@@ -1,9 +1,9 @@
 [CmdletBinding()]
 param (
     #Added this back into parameters as error occurs if multiple tenants are found when using Get-AzTenant
-    [Parameter(Mandatory = $true, Position = 1, HelpMessage = "Please the Insert Tenant ID (GUID) of your Azure AD tenant e.g.'f73a2b89-6c0e-4382-899f-ea227cd6b68f'")]
+    [Parameter(Mandatory = $true, Position = 1, HelpMessage = "Please the Insert Tenant ID (GUID) of your Microsoft Entra tenant e.g.'f73a2b89-6c0e-4382-899f-ea227cd6b68f'")]
     [string]
-    $tenantRootGroupID = "<Insert the Tenant ID (GUID) of your Azure AD tenant>",
+    $tenantRootGroupID = "<Insert the Tenant ID (GUID) of your Microsoft Entra tenant>",
 
     [Parameter(Mandatory = $true, Position = 2, HelpMessage = "Insert the name of your intermediate root Management Group e.g. 'Contoso'")]
     [string]
@@ -52,12 +52,12 @@ $subDeployments | ForEach-Object -Parallel {
 }
 
 
-# Get all AAD Tenant level deployments
+# Get all Microsoft Entra Tenant level deployments
 $tenantDeployments = Get-AzTenantDeployment
 
 Write-Information "Removing all Tenant level deployments"
 
-# For each AAD Tenant level deployment, remove it
+# For each Microsoft Entra Tenant level deployment, remove it
 $tenantDeployments | ForEach-Object -Parallel {
     Write-Information "Removing $($_.DeploymentName) ..."
     Remove-AzTenantDeployment -Id $_.Id

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 >
 > ℹ️ This module is also available on the Bicep Module Registry [here](https://github.com/Azure/bicep-registry-modules/tree/main/modules/lz/sub-vending). Examples also included in our [wiki examples](https://github.com/Azure/bicep-lz-vending/wiki/examples). ℹ️
 
-The landing zone Bicep modules are designed to accelerate deployment of the individual landing zones (aka Subscriptions) within an Azure AD Tenant.
+The landing zone Bicep modules are designed to accelerate deployment of the individual landing zones (aka Subscriptions) within an Microsoft Entra Tenant.
 
 > See the different types of landing zones in the Azure Landing Zones documentation here: [What is an Azure landing zone? - Platform vs. application landing zones](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/#platform-vs-application-landing-zones)
 

--- a/docs/wiki/ConsumerGuide.md
+++ b/docs/wiki/ConsumerGuide.md
@@ -7,7 +7,34 @@ This repository has been created to help customers and partners to create, deplo
 
 ## Ways to Consume `bicep-lz-vending`
 
-There are various ways to consume the Bicep modules included in `bicep-lz-vending`. The options are:
+### Recommended Way to Consume
+
+The recommend way is to consume the module directly from the [Bicep public registry](https://github.com/Azure/bicep-registry-modules/tree/main/modules/lz/sub-vending#examples)
+
+```bicep
+targetScope = 'managementGroup'
+
+module sub001 'br/public:lz/sub-vending:1.5.1' = {
+  name: 'sub001'
+  params: {
+    subscriptionAliasEnabled: true
+    subscriptionBillingScope: '/providers/Microsoft.Billing/billingAccounts/1234567/enrollmentAccounts/123456'
+    subscriptionAliasName: 'sub-test-001'
+    subscriptionDisplayName: 'sub-test-001'
+    subscriptionTags: {
+      example: 'true'
+    }
+    subscriptionWorkload: 'Production'
+    subscriptionManagementGroupAssociationEnabled: true
+    subscriptionManagementGroupId: 'corp'
+    // Other parameter inputs available, see docs
+  }
+}
+```
+
+### Other Ways to Consume
+
+There are a number of other ways to consume the Bicep modules included in `bicep-lz-vending`. The options are:
 
 - Creating your own GitHub Repository & Utilizing the `Invoke-GitHubReleaseFetcher.ps1` script & `gh-release-checker.yml` GitHub Action Workflow
   - See detailed instruction on using this [below](#creating-your-own-github-repository--utilizing-the-invoke-githubreleasefetcherps1-script--gh-release-checkeryml-github-action-workflow)

--- a/docs/wiki/ConsumerGuide.md
+++ b/docs/wiki/ConsumerGuide.md
@@ -3,7 +3,7 @@
 
 ## Background
 
-This repository has been created to help customers and partners to create, deploy and deliver landing zone Subscriptions into an Azure AD Tenant utilizing [Bicep](https://aka.ms/bicep) as the Infrastructure-as-Code (IaC) tooling and language of choice.
+This repository has been created to help customers and partners to create, deploy and deliver landing zone Subscriptions into an Microsoft Entra Tenant utilizing [Bicep](https://aka.ms/bicep) as the Infrastructure-as-Code (IaC) tooling and language of choice.
 
 ## Ways to Consume `bicep-lz-vending`
 

--- a/main.bicep
+++ b/main.bicep
@@ -4,7 +4,7 @@ targetScope = 'managementGroup'
 
 metadata name = '`main.bicep` Parameters'
 
-metadata description = 'This module is designed to accelerate deployment of landing zones (aka Subscriptions) within an Azure AD Tenant.'
+metadata description = 'This module is designed to accelerate deployment of landing zones (aka Subscriptions) within an Microsoft Entra Tenant.'
 
 metadata details = '''These are the input parameters for the Bicep module: [`main.bicep`](./main.bicep)
 

--- a/main.bicep.parameters.md
+++ b/main.bicep.parameters.md
@@ -1,6 +1,6 @@
 # `main.bicep` Parameters
 
-This module is designed to accelerate deployment of landing zones (aka Subscriptions) within an Azure AD Tenant.
+This module is designed to accelerate deployment of landing zones (aka Subscriptions) within an Microsoft Entra Tenant.
 
 ## Parameters
 

--- a/tests/pester/full.tests.ps1
+++ b/tests/pester/full.tests.ps1
@@ -62,7 +62,7 @@ Describe "Bicep Landing Zone (Sub) Vending Tests" {
   }
 
   Context "Role-Based Access Control Assignment Tests" {
-    It "Should Have a Role Assignment for an known AAD Group with the Reader role directly upon the Subscription" {
+    It "Should Have a Role Assignment for an known Microsoft Entra Group with the Reader role directly upon the Subscription" {
       $iterationCount = 0
       do {
         $roleAssignment = Get-AzRoleAssignment -Scope "/subscriptions/$subId" -RoleDefinitionName "Reader" -ObjectId "7eca0dca-6701-46f1-b7b6-8b424dab50b3" -ErrorAction SilentlyContinue
@@ -80,7 +80,7 @@ Describe "Bicep Landing Zone (Sub) Vending Tests" {
       $roleAssignment.scope | Should -Be "/subscriptions/$subId"
     }
 
-    It "Should Have a Role Assignment for an known AAD Group with the Network Contributor role directly upon the Resource Group" {
+    It "Should Have a Role Assignment for an known Microsoft Entra Group with the Network Contributor role directly upon the Resource Group" {
       $iterationCount = 0
       do {
         $roleAssignment = Get-AzRoleAssignment -Scope "/subscriptions/$subId/resourceGroups/rsg-$location-net-hs-pr-$prNumber" -RoleDefinitionName "Network Contributor" -ObjectId "7eca0dca-6701-46f1-b7b6-8b424dab50b3" -ErrorAction SilentlyContinue


### PR DESCRIPTION
This pull request includes changes to update the terminology used in various files to reflect the correct terminology of "Microsoft Entra Tenant" instead of "Azure AD Tenant". The most important changes include updating the help message, comments, and log messages in the `Wipe-AlzTenant.ps1` script, as well as updating the description in the `README.md` file.

Main terminology updates:

* <a href="diffhunk://#diff-cd55c9551152647a9adaca9eef7fa4780994110ca0a0c5cd87e90772d7953f35L4-R6">`.github/scripts/Wipe-AlzTenant.ps1`</a>: Updated the help message, comments, and log messages in the `Wipe-AlzTenant.ps1` script to reflect the correct terminology of "Microsoft Entra Tenant" instead of "Azure AD Tenant". <a href="diffhunk://#diff-cd55c9551152647a9adaca9eef7fa4780994110ca0a0c5cd87e90772d7953f35L4-R6">[1]</a> <a href="diffhunk://#diff-cd55c9551152647a9adaca9eef7fa4780994110ca0a0c5cd87e90772d7953f35L55-R60">[2]</a>
* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12">`README.md`</a>: Updated the description in `README.md` to correct the terminology from "Azure AD Tenant" to "Microsoft Entra Tenant".

Other terminology updates:

* <a href="diffhunk://#diff-9c043e8e6d62139031fa1ca1a0642c7123bc4cf9ad3d5583f0f1517622f908d1L65-R65">`tests/pester/full.tests.ps1`</a>: Updated the description of a test case in the `full.tests.ps1` script to reflect the correct terminology of "Microsoft Entra Group" instead of "AAD Group". <a href="diffhunk://#diff-9c043e8e6d62139031fa1ca1a0642c7123bc4cf9ad3d5583f0f1517622f908d1L65-R65">[1]</a> <a href="diffhunk://#diff-9c043e8e6d62139031fa1ca1a0642c7123bc4cf9ad3d5583f0f1517622f908d1L83-R83">[2]</a>
* <a href="diffhunk://#diff-d1908a35d4a970592156c9f0ac3768fff9f6b7bbca2863e39e10bce981b9f072L6-R6">`docs/wiki/ConsumerGuide.md`</a>: Updated the description in `ConsumerGuide.md` to use the correct terminology "Microsoft Enterprise Tenant" instead of "Azure AD Tenant".
* <a href="diffhunk://#diff-c4ce7d04c6432863193f9344ff085b8d1c78a351a527564383f793f989cc7669L3-R3">`main.bicep.parameters.md`</a>: Updated the description in `main.bicep.parameters.md` to correct the terminology from "Azure AD Tenant" to "Microsoft Entra Tenant".
* <a href="diffhunk://#diff-f4ecc8ae574855a8ef50bcf47bd2fa00d1ed8a57c178718b3a5d3d098b57db14L7-R7">`main.bicep`</a>: Updated the description in `main.bicep` from "Azure AD Tenant" to "Microsoft Entra Tenant" to reflect the correct terminology.
